### PR TITLE
Don't crash BeforeRender and NewResponse if no timings are present

### DIFF
--- a/pyramid_datadog/__init__.py
+++ b/pyramid_datadog/__init__.py
@@ -62,21 +62,29 @@ def on_context_found(context_found_event):
 
 def on_before_render(before_render_event):
     request = before_render_event['request']
+    if not hasattr(request, 'timings'):
+        return request
 
     timings = request.timings
-    timings['view_duration'] = time_ms() - timings['view_code_start']
+    if 'view_code_start' in timings:
+        timings['view_duration'] = time_ms() - timings['view_code_start']
     timings['before_render_start'] = time_ms()
 
     route_tag = 'route:%s' % request.matched_route.name
 
-    request.registry.datadog.timing(
-        'pyramid.request.duration.view',
-        timings['view_duration'],
-        tags=[route_tag],
-    )
+    if 'view_duration' in timings:
+        request.registry.datadog.timing(
+            'pyramid.request.duration.view',
+            timings['view_duration'],
+            tags=[route_tag],
+        )
 
 
 def on_new_response(new_response_event):
+    request = new_response_event.request
+    if not hasattr(request, 'timings'):
+        return
+
     request = new_response_event.request
     new_response_time = time_ms()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ addopts =
     --cov=pyramid_datadog
     --cov-report=term-missing
     --cov-report=xml
+    --cov-branch


### PR DESCRIPTION
Fixes from:

- https://github.com/pypa/warehouse/commit/ddcf451925c345bd20da411028564da9d092905d
- https://github.com/pypa/warehouse/pull/3686
- internal GoodRx code

Also adds branch coverage measurement to verify these are tested.